### PR TITLE
"Film Grain" filter: adding Film Format presets, choice for grain Normalise/Cut/None

### DIFF
--- a/include/marcos_capelini.gmic
+++ b/include/marcos_capelini.gmic
@@ -13,7 +13,7 @@
 #@gui <i>Marcos Capelini</i>
 
 #@gui Film Grain: mc_film_grain,mc_film_grain_preview(0)*
-#@gui : _=note("<u><b>Grain pattern</b></u>")
+#@gui : _=note("<u><b>Grain Pattern</b></u>")
 #@gui : Grain Pattern File: =file()
 #@gui : Texture Generator: =choice("Syntexturize", "Patch matching")
 #@gui : _=separator()
@@ -21,13 +21,17 @@
 #@gui : Blend Mode: =choice(1,"Grain Only","Grain Merge","Overlay","Soft Light","Hard Light","Alpha")
 #@gui : Opacity (%): =float(20,0,100)
 #@gui : _=separator()
-#@gui : _=note("<u><b>Grain appearance</b></u>")
+#@gui : _=note("<u><b>Grain Size</b></u>")
+#@gui : Film Format: =choice(0,"135 &#40;35mm&#41;","135 Half-frame &#40;Olympus PEN&#41;","110 &#40;Pocket Instamatic&#41;","120 &#40;Medium Format&#41;","APS &#40;H&#44;C&#44;P auto-detect&#41;" )
 #@gui : Scale (%): =int(100,20,300)
+#@gui : _=separator()
+#@gui : _=note("<u><b>Grain Appearance</b></u>")
 #@gui : Sharpness (radius) = float(0,-5,20)
 #@gui : Contrast: = int(0,-100,100)
 #@gui : Gamma: = int(0,-50,50)
 #@gui :_=separator()
-#@gui : _=note("<u><b>Normalisation:</u></b>")
+#@gui : _=note("<u><b>Grain Normalise/Cut:</u></b>")
+#@gui : Mode: =choice(1,"None","Normalise","Cut")
 #@gui : Lowest Value: = int(0,0,127)
 #@gui : Highest Value: = int(255,128,255)
 #@gui : _=separator()
@@ -35,73 +39,100 @@
 ##@gui :Content =choice("Filter Output","Grain Only")
 #@gui :Preview Grain Only: =bool(false)
 #@gui :_=separator()
-#@gui :_=note("<small>This filter applies a film grain pattern over an image. A grain pattern file must be provided by the user and is assumed to be a patch of digitised 35mm film grain at 24MP, meaning 6000x4000 px.</small>")
-#@gui :_=note("<small>The filter will internally up or down scale the grain pattern based on the actual resolution of the current image. A full-image-sized grain texture is then generated using the selected pattern generating algorithm.</small>")
+#@gui :_=note("<small>This filter applies a film grain pattern over an image. A grain pattern file must be provided by the user. If smaller than 6MP,it is assumed to be a crop of digitised 35mm film grain at 24MP. If 6MP or more, its is treated as a full 35mm frame of digitised grain.</small>") 
+#@gui :_=note("<small>The filter will internally up or down scale the grain pattern based on the actual resolution of the current image, and the selected output Film Format. A full-image-sized grain texture is then generated using the selected pattern generating algorithm.</small>")
 #@gui :_=note("<small>Several properties can be changed to taste to achieve the desired grain appearance. The resulting grain pattern can be further normalised, which affects the end result depending on the selected blend mode.</small>")
 #@gui :_=separator()
-#@gui :_=note("<small>Author: <i>Marcos Capelini</i>.</small>")
+#@gui :_=note("<small>Author: <i>Marcos Capelini</i>. Latest Update: 2023/04/11</small>")
 #@gui :_=note("<small>Based on the \"Add Grain\" filter by: <i><a href="http://bit.ly/2CmhX65">David Tschumperlé</a></i>.</small>")
 
 mc_film_grain :
-  __mc_film_grain_grain 0,{max(w,h)},$"*"
-
+  __mc_film_grain 0,{max(w,h)},{min(w,h)},$"*"
+    
 mc_film_grain_preview :
-  max_dimension={max(w,h)}
+  long_side={max(w,h)}
+  short_side={min(w,h)}
   gui_crop_resize_preview  # Extract preview thumbnail from full image
-  __mc_film_grain_grain 1,$max_dimension,$"*"
-
-#
+  __mc_film_grain 1,$long_side,$short_side,$"*"
+      
+#      
 # Internal command for the "Film Grain" filter
 #
-__mc_film_grain_grain :
+__mc_film_grain :
 
   # For easier maintenance and code docummentation, define named variables for each positional command argument
-
+  
   is_preview,\
-  max_img_dimension,\
+  img_long_side,img_short_side,\
   grain_file_path,texture_type,\
   blend_mode_opt,blend_opacity,\
+  film_fmt_opt,\  
   scale_pct,\
   gr_sharpness,\
   gr_contrast,gr_gamma,\
-  gr_norm_low,gr_norm_high,\
+  gr_norm_opt,gr_norm_low,gr_norm_high,\
   preview_grain=$"*"
 
   # Blend modes: must follow the same order declared in the "Blend Mode" filter argument
-
-  blend_modes=alpha,grainmerge,overlay,softlight,hardlight,alpha
-
+  
+  blend_modes=alpha,grainmerge,overlay,softlight,hardlight,alpha 
+  
   # Load selected grain pattern image
-
+   
   local {
     input $grain_file_path
-    normalize. 0,255
+    normalize. 0,255         
   onfail
     if $is_preview
       msg="This filter requires a grain pattern file as input. Sample grain files are\n"
-      msg.="not included with this filter, and must be provided by the user.\n\n"
+      msg.="not included with this filter, and must be provided by the user.\n\n"    
       msg.="A grain pattern file must be a valid image file containing a patch of scanned\n"
-      msg.="or simulated film grain, typically as a square at least 500x500 px.\n\n"
+      msg.="or simulated film grain, recommended to be a square 1000x1000 px.\n\n"
       msg.="For best results, grain patterns are assumed to be crops of 35mm full-frame\n"
       msg.="images at 24Mp, meaning 6000x4000 px, so the grain is properly scaled based\n"
-      msg.="on the current image width.\n\n"
+      msg.="on the current image width.\n\n"            
       msg.="If the grain pattern file is 6MP or greater, it will be cropped to 1000x1000\n"
       msg.="and its width will be used instead as a reference for scaling the grain."
       gui_print_preview "Warning:",,$msg
     fi
-    return
+    return    
   }
-
+    
+  # Adjust scale factor based on desired output film format choice
+  # notes: 
+  # - these are just some quick-and-dirty calculations to get grain size in the righ ballpark
+  # - we don't really care about the aspect ratio except for MF & APS, where some heuristics 
+  #   are applied to select the best scale divider depending on the current image proportions
+   
+  aspect={$img_long_side/$img_short_side}     # image aspect ratio
+  if $film_fmt_opt==1 scale_pct/=0.75       # 135 half-frame
+  elif $film_fmt_opt==2 scale_pct/=0.54     # 110 Pocket Instamatic
+  elif $film_fmt_opt==3                     # 120 MF film (6x45, 6×6, 6x7, ...) 
+    if "$aspect<1.355 && $aspect>1.34"      # - 6x45: aspect 1:1.35 => check with tollerance for sloppy crop
+        scale_pct/=1.77                     #   scale = 41.5mm/24mm
+    else
+        scale_pct/=2.33                     # - all other MF frame sizes assume scale = 56mm/24mm
+    fi
+  elif $film_fmt_opt==4                     # APS (H,C,P)
+      if $aspect>=3                         # - P (Panoramic): aspect 1:3
+        scale_pct/=0.3958                   #   scale = 9.5mm/24mm
+    else
+        scale_pct/=0.6958                   # - all other APS frame sizes assume scale = 16.7mm/24mm
+    fi    
+  fi 
+    
   # Original grain scan width assumed to be 6000px (35mm frame at 24MP=6000x4000px)
-  ref_frame_size=6000
-
+  ref_frame_long=6000
+  ref_frame_short=4000
+    
   # If grain pattern image is large enough (at least 6MP), assume it's a full-frame scan
   # => set reference width for scaling, and crop image so the remaing of the code runs unchanged
   if "max(w,h) > 3000 && min(w,h) > 2000"
-    ref_frame_size={max(w,h)}
-    crop. 0,0,1000,1000
+    ref_frame_long={max(w,h)}
+    ref_frame_short={min(w,h)}
+    crop. {w/2-500},{h/2-500},{w/2+500},{h/2+500}   # take crop from centre
   fi
-
+       
   foreach[^-1] {
     split_opacity
     pass. 0
@@ -111,43 +142,47 @@ __mc_film_grain_grain :
     if $gr_sharpness>0
       unsharp. 100,$gr_sharpness n. 0,255
     elif $gr_sharpness<00
-      blur. {-1*$gr_sharpness}
+      blur. {-1*$gr_sharpness}      
     fi
 
     # Adjust contrast and gamma to taste
-    adjust_colors. 0,$gr_contrast,$gr_gamma,0,0 c. 0,255
-
-    # Resize pattern for proper grain size
-    resize2dx. {w*$max_img_dimension/$ref_frame_size}
+    adjust_colors. 0,$gr_contrast,$gr_gamma,0,0 c. 0,255                                         
+    
+    # Resize pattern for proper grain size  
+    resize2dx. {w*$img_short_side/$ref_frame_short}
 
     # Generate grain texture image
     if $texture_type==0
       +syntexturize. {0,max(10,100*w/$scale_pct)},{0,max(10,100*h/$scale_pct)}
     else
-      +syntexturize_matchpatch. {0,max(10,100*w/$scale_pct)},{0,max(10,100*h/$scale_pct)}
-    fi
-
+      +syntexturize_matchpatch. {0,max(10,100*w/$scale_pct)},{0,max(10,100*h/$scale_pct)}      
+    fi     
+    
     # Grain normalisation, ajusting range low and high values (shift min/max grain values)
     # => affects result in different ways depending on blend mode
-    normalize. $gr_norm_low,$gr_norm_high
-
+    if $gr_norm_opt==1
+      normalize. $gr_norm_low,$gr_norm_high
+    elif $gr_norm_opt==2
+      cut. $gr_norm_low,$gr_norm_high
+    fi
+    
     # Resize grain pattern to image size before blending
     resize {0,w},{0,h},1,100%,5 c. 0,255
-
-    # Show only the grain layer, or apply filter result
-    if "$preview_grain && $is_preview"
-      keep[0,-1]
+    
+    # Show only the grain layer, or apply filter result     
+    if "$preview_grain && $is_preview"        
+      keep[0,-1] 
       reverse
-    else
+    else 
       blend[0,-1] ${arg\ {$blend_mode_opt+1},$blend_modes},{if($blend_mode_opt>0,$blend_opacity/100,1)}
     fi
-
+    
     # debug
-    # text_outline {w}" x "{h}", full-width: "$full_width,2,2,23,2,1,255
-
-    append[^-1] c
+    # text_outline {w}" x "{h}", full-width: "$full_width,2,2,23,2,1,255              
+    
+    append[^-1] c 
     remove.
-  }
+  }  
   remove.
 
 # Local Variables:


### PR DESCRIPTION
- New option to select an output Film Format preset (35mm, 35mm half-frame, 110, 120, APS).  This will scale the grain to approximate the appearance of the selected film pattern for a given film format.
- Option to disable grain normalisation, or to use 'cut' instead of 'normalize'
- If grain pattern is detected as full-frame scan, grain sample now is taken off the centre of image instead of off top-left corner.