### PR TITLE
Added global angle to sloppymess

### DIFF
--- a/include/prawnsushi.gmic
+++ b/include/prawnsushi.gmic
@@ -43,7 +43,8 @@
 
 #@gui Sloppy Mess : fx_sloppymess, fx_sloppymess_preview(0)*
 #@gui : note = note("<span color="#EE5500"><small><b>Slices:</b></small></span>")
-#@gui : Width (px) = int(1,1,2000)
+#@gui : Angle = int(0,0,360)
+#@gui : Width (px) = int(1,1,5000)
 #@gui : Axis = choice("X-Axis","Y-Axis")
 #@gui : Mirror Axis = choice("X-Axis","Y-Axis")
 #@gui : sep = separator()
@@ -67,9 +68,9 @@
 #@gui : Strength = float(100,0,100)
 #@gui : sep = separator()
 #@gui : note = note("<small>Author: <i><a href="http://prawnsushi.free.fr">Prawnsushi</i></a>.      \
-# Latest Update: <i>2023/11/06</i>.</small>")
-fx_sloppymess : skip "${1=1},${2=1},${3=1},${4=35},${5=-35},${6=2},${7=0},${8=0},${9=3},${10=1},${11=3},${12=100}"
-  arg0 $11,\
+# Latest Update: <i>2023/14/06</i>.</small>")
+fx_sloppymess : skip "${1=0},${2=1},${3=1},${4=1},${5=35},${6=-35},${7=2},${8=0},${9=0},${10=3},${11=1},${12=3},${13=100}"
+arg0 $12,\
        "add","alpha","and","average","blue","burn","darken","difference","divide","dodge","edges","exclusion","freeze",\
        "grainextract","grainmerge","green","hardlight","hardmix","hue","interpolation","lchlightness","lighten",\
        "lightness","linearburn","linearlight","luminance","multiply","negation","or","overlay","pinlight","red",\
@@ -80,16 +81,18 @@ fx_sloppymess : skip "${1=1},${2=1},${3=1},${4=35},${5=-35},${6=2},${7=0},${8=0}
   n 0,255
 
   foreach {
-    wi,he:=w,h
 
-    repeat $10
-      if $2==0 spins,dir,sli={w/$1},x,y else spins,dir,sli={h/$1},y,x fi
-      if $3==0 mir=x else mir=y fi
+    wi,he:=w,h
+    if $1>0&&$1!=360 rotate $1,0,3 fi
+
+    repeat $11
+      if $3==0 spins,dir,sli={w/$2},x,y else spins,dir,sli={h/$2},y,x fi
+      if $4==0 mir=x else mir=y fi
 
       +s. $dir,$spins
       repeat $spins {
         l[{$>+1}] {
-          if $4||$5 rotate {u($4,$5)},0,$6,$7%,$8% fi
+          if $5||$6 rotate {u($5,$6)},0,$7,$8%,$9% fi
           p={($>+1)%2}
           if $p==0 mirror $mir fi
         }
@@ -98,12 +101,18 @@ fx_sloppymess : skip "${1=1},${2=1},${3=1},${4=35},${5=-35},${6=2},${7=0},${8=0}
       a[^0] $dir
       +gradient_norm.
       negate.
-      deform[^0] $9
+      deform[^0] $10
       blend[^0] edges,1
       equalize.
-      blend $blending_mode,$12
+      blend $blending_mode,$13%
     done
   }
+  if $1>0&&$1!=360
+    rotate. -$1,0,3
+    vx,vy={floor((w-$wi)/2)},{floor((h-$he)/2)}
+    vxb,vyb={$vx+$wi-1},{$vy+$he-1}
+    crop. $vx,$vy,$vxb,$vyb
+  fi
   equalize
 
 fx_sloppymess_preview :


### PR DESCRIPTION
Added global angle to sloppymess so that you can now rotate the image before splitting, then rotate it back, before cropping. Result is like some kind of angled splitting. Maybe not the best way to do it but it seems to work.