### PR TITLE
Added a filter to prawnsushi.gmic

### DIFF
--- a/include/prawnsushi.gmic
+++ b/include/prawnsushi.gmic
@@ -268,26 +268,14 @@ if $wc
     [ORIG] nm. FUZZ
     l[FUZZ] {
       fc 255,255,255
-#       fc 0,0,0
-#       negate
-#       frame_fuzzy $fuzz
-#       shared 100%
-#       rectangle 0%,0%,100%,100%,1,0,0,0
-#       n 0,255 d
       rectangle $fuzz%,$fuzz%,{100-$fuzz}%,{100-$fuzz}%,1,0
       if $fuzzblur b $fuzzblur,0 fi
       repeat 10 {
         deform $fuzz
         spread {$fuzz/2},{$fuzz/2}
       }
-#         shared 100% negate. rm.
-#         split c rm. . negate. a c
-#         split c rm[^-1] negate.
       if $fuzstr!=1 mul $fuzstr fi
-#     n 0,255 d
     }
-#     rm. d
-#     split[REND] c  rm..  a[^0] c
     blend_median[REND,FUZZ]  fi
 fi
 
@@ -329,9 +317,6 @@ if $sketch
       deform {0,w/2000} rolling_guidance {31-$sklike},20,0
       if {$__ORIGW/2}>1500 r 200%,200%,1,4,6 fi
       gradient_norm negate
-#         edges 9%
-#     . negate.. deform. 4 split. c +compose_channels.. mul append[^0] c
-#       blend alpha,1
       if $brkstr>0
         . repeat 2 fx_breaks. 1,5,20,0,3  done
         blend[-1,-2,LINE] multiply,$brkstr
@@ -347,18 +332,13 @@ if $sketch
     +store. line
     }
     split[REND] c a[1,2,3] c
-#     shared[REND] 100% . rm.. d
     blend[LINE,REND] $skmerge,$linestr
-#     to_rgb.
-#     +compose_channels. +
-#     a[-1,-2] c
   if $wl>0
     $line negate. erode_circ. {$linthick/2}
     if $wldef deform. $wldef fi
     . blend[REND,LINE] or,$wl blend[-1,-2] add,1
   fi
   a[REND] [-1],c
-#   rm. d
   fi
 fi
 
@@ -394,12 +374,6 @@ move[-1] 0
 blend[0,REND] alpha
 nm[0] REND
 keep[REND]
-
-#  +adjust_colors. 0,100,50
-# . repeat 2 glow. 1%  done sharpen. 100 to_gray.
-# b. 5 d
-
-#  blend burn,0.6
 
 if $post
   if $emboss fx_emboss_relief 5,0,0.5,$emboss,1,0,1 fi

--- a/include/prawnsushi.gmic
+++ b/include/prawnsushi.gmic
@@ -117,6 +117,11 @@ arg0 $12,\
 fx_sloppymess_preview :
   fx_sloppymess $*
 
+#-------------------------
+#@gui _<b>Testing</b>
+#@gui <i>Prawnsushi</i>
+#-------------------------
+
 #@gui Uglify : uglify, uglify_preview(0)
 #@gui : Write settings on picture = int(0,0,1)
 #@gui : note = note{"<small>Use original input image resolution or choose processing resolution (i.e. Half res + Upscale 2x). Beware: Preview lies.</small>"}

--- a/include/prawnsushi.gmic
+++ b/include/prawnsushi.gmic
@@ -117,6 +117,343 @@ arg0 $12,\
 fx_sloppymess_preview :
   fx_sloppymess $*
 
+#@gui Uglify : uglify, uglify_preview(0)
+#@gui : Write settings on picture = int(0,0,1)
+#@gui : note = note{"<small>Use original input image resolution or choose processing resolution (i.e. Half res + Upscale 2x). Beware: Preview lies.</small>"}
+#@gui : Original Resolution = int(1,0,1)
+#@gui : Processing Resolution = int(1000,500,5000)
+#@gui : Upscale 2x (Iterations) = _int(0,0,5)
+#@gui : sep = separator()
+#@gui : - Presets = choice(0,"Default","1 - From Scratch","2 - Soft","3- Cracked","4 - Black","5 - Faded Black","6 - Nuudlz for a blank page")
+#@gui : sep = separator()
+#@gui : Pre-Process = int(0,0,1)
+#@gui : - Sharpening = int(0,0,500)
+#@gui : - Blur = float(0,0,10)
+#@gui : - Local normalization = float(0,0,3)
+#@gui : sep = separator()
+#@gui : Sloppiness = int(1,0,1)
+#@gui : - Distort = float(3,0,20)
+#@gui : - Blur = float(3,0,50)
+#@gui : - Blend Mode = choice(13,"add","and","average","blue","burn","darken","difference","divide","dodge","exclusion","grainextract","grainmerge","green","hardlight","hardmix","hue","interpolation","lighten","lightness","linearburn","linearlight","luminance","multiply","negation","or","overlay","pinlight","red","reflect","saturation","screen","shapeaverage","softburn","softdodge","softlight","stamp","subtract","value","vividlight","xor")
+#@gui : - Strength = float(0.5,0.0,1.0)
+#@gui : sep = separator()
+#@gui : Watering = int(1,0,1)
+#@gui : - Smoothing = int(12,0,40)
+#@gui : - Iterations = int(1,0,10)
+#@gui : Fuzzy Frame Size (%) = float(5,0,45)
+#@gui : - Frame Blur = int(20,0,150)
+#@gui : - Frame Strentgh = float(0.5,0,1)
+#@gui : Plasma Seed ( -1 : Random ) = int{-1,-1,999999}
+#@gui : - Plasma Saturation = int(-100,-100,100)
+#@gui : - Plasma Blur = float(0,0,50)
+#@gui : - Blend Mode = choice(7,"add","and","average","blue","burn","darken","difference","divide","dodge","exclusion","grainextract","grainmerge","green","hardlight","hardmix","hue","interpolation","lighten","lightness","linearburn","linearlight","luminance","multiply","negation","or","overlay","pinlight","red","reflect","saturation",screen","shapeaverage","softburn","softdodge","softlight","stamp","subtract","value","vividlight","xor")
+#@gui : - Plasma Strength = float(0.6,0,1)
+#@gui : sep = separator()
+#@gui : Cracks = int(1,0,1)
+#@gui : Sharpening = int(150,0,500)
+#@gui : - Shock Filter = int(1,0,1)
+#@gui : Light Relief (0 means all off) = float(0.05,0,1)
+#@gui : - Light2 = float(0.02,0,1)
+#@gui : - Light3 = float(0.02,0,1)
+#@gui : sep = separator()
+#@gui : Sketch = int(1,0,1)
+#@gui : - Likeness = int(25,0,30)
+#@gui : - Contrast = int(0,-100,100)
+#@gui : - Gamma = int(0,-100,100)
+#@gui : - Thickness = int(2,0,40)
+#@gui : - Sketch strength = float(1,0,1)
+#@gui : --- Messy lines = float(0.8,0,1)
+#@gui : - White lines = float (0.6,0,1)
+#@gui : --- W. L. Deform = float (1.6,0,40)
+#@gui : - Blend Mode = choice(22,"add","and","average","blue","burn","darken","difference","divide","dodge","exclusion","grainextract","grainmerge","green","hardlight","hardmix","hue","interpolation","lighten","lightness","linearburn","linearlight","luminance","multiply","negation","or","overlay","pinlight","red","reflect","saturation",screen","shapeaverage","softburn","softdodge","softlight","stamp","subtract","value","vividlight","xor")
+#@gui : note = note("<small>Setting Sktech Strength to 0 disables Messy lines too.\n Messy lines uses 'Breaks' by David Tschumperlé.</small>")
+#@gui : sep = separator()
+#@gui : Noise = float(3,0,6)
+#@gui : Canvas = float(0.3,0,1)
+#@gui : Canvas density = int(0,0,100)
+#@gui : Color = color(255,255,255,255)
+#@gui : sep = separator()
+#@gui : Post-Process = int(1,0,1)
+#@gui : Emboss = float(1.5,0,5)
+#@gui : Mix Original Hue/Sat = float(0.5,0,1)
+#@gui : Brightness = float(0,-100,100)
+#@gui : Contrast = float(0,-100,100)
+#@gui : Gamma = float(0,-100,100)
+#@gui : Hue = float(0,-100,100)
+#@gui : Saturation = float(0,-100,100)
+#@gui : sep = separator()
+#@gui : - Old Presets = _choice(0,"Default","1 - From Scratch","2 -Soft","3 - Cracked","4 - Black","5 - Faded Black","6 - Nuudlz for blank page")_0
+#@gui : sep = separator()
+#@gui : note = note("<small>Author: <i><a href="http://prawnsushi.free.fr">Prawnsushi</i></a>.      \
+# Latest Update: <i>2023/16/06</i>.</small>")
+
+uglify :
+
+com,origres,procres,dccires,preset,bst,bstsharp,bstblur,locnorm,\
+filt,dist,distblur,distmerge,diststr,wc,bilsize,bilrep,fuzz,fuzzblur,\
+fuzstr,plsmseed,plsmsat,plsmblur,plasmerge,plastr,cracks,sckrad,sck,lgtone,\
+lgttwo,lgthree,sketch,sklike,cutmin,cutmax,linthick,linestr,brkstr,wl,wldef,skmerge,\
+noistr,cnvs,cvmod,cvr,cvg,cvb,cva,post,emboss,huestr,\
+bri,con,gam,hue,sat=${1-56}
+
+arg0 $distmerge,\
+    "add","and","average","blue","burn","darken","difference","divide","dodge","exclusion","grainextract","grainmerge",\
+    "green","hardlight","hardmix","hue","interpolation","lighten","lightness","linearburn","linearlight","luminance","multiply",\
+    "negation","or","overlay","pinlight","red","reflect","saturation","screen","shapeaverage","softburn","softdodge","softlight",\
+    "stamp","subtract","value","vividlight","xor"
+distmerge=${}
+
+arg0 $plasmerge,\
+    "add","and","average","blue","burn","darken","difference","divide","dodge","exclusion","grainextract","grainmerge",\
+    "green","hardlight","hardmix","hue","interpolation","lighten","lightness","linearburn","linearlight","luminance","multiply",\
+    "negation","or","overlay","pinlight","red","reflect","saturation","screen","shapeaverage","softburn","softdodge","softlight",\
+    "stamp","subtract","value","vividlight","xor"
+plasmerge=${}
+
+arg0 $skmerge,\
+    "add","and","average","blue","burn","darken","difference","divide","dodge","exclusion","grainextract","grainmerge",\
+    "green","hardlight","hardmix","hue","interpolation","lighten","lightness","linearburn","linearlight","luminance","multiply",\
+    "negation","or","overlay","pinlight","red","reflect","saturation","screen","shapeaverage","softburn","softdodge","softlight",\
+    "stamp","subtract","value","vividlight","xor"
+skmerge=${}
+
+to_rgba
+nm[0] ORIG
+__ORIGW={0,w}
+__ORIGH={0,h}
+if !$origres res=$procres,$procres rr2d[ORIG] $res,0,6 fi
+n 0,255
+
+if $bst
+  if $bstblur b $bstblur fi
+  if $bstsharp sharpen $bstsharp fi
+  if $locnorm normalize_local $locnorm,$locnorm fi
+fi
+
+[ORIG] nm. REND
+
+if $filt
+  if $diststr
+    [ORIG] nm. FILT
+    l[REND,FILT] {
+      usrmod=$dist,$distblur
+      if [$usrmod]!=[0,0]
+        if $dist apc. "deform $dist" fi
+        if $distblur b. $distblur fi
+        blend[REND,FILT] $distmerge,$diststr
+        n[REND] 0,255
+      fi
+    }
+  fi
+fi
+
+if $wc
+  if $plastr
+    [ORIG] nm. PLAS
+    l[PLAS] {
+      if $plsmseed>-1 srand $plsmseed fi
+      plasma 1,2,5
+      if $plsmsat!=0 adjust_colors 0,0,0,0,$plsmsat fi
+      if $plsmblur>0 b $plsmblur fi
+    }
+    blend[REND,PLAS] $plasmerge,$plastr
+  fi
+
+  if $fuzz
+    [ORIG] nm. FUZZ
+    l[FUZZ] {
+      fc 255,255,255
+#       fc 0,0,0
+#       negate
+#       frame_fuzzy $fuzz
+#       shared 100%
+#       rectangle 0%,0%,100%,100%,1,0,0,0
+#       n 0,255 d
+      rectangle $fuzz%,$fuzz%,{100-$fuzz}%,{100-$fuzz}%,1,0
+      if $fuzzblur b $fuzzblur,0 fi
+      repeat 10 {
+        deform $fuzz
+        spread {$fuzz/2},{$fuzz/2}
+      }
+#         shared 100% negate. rm.
+#         split c rm. . negate. a c
+#         split c rm[^-1] negate.
+      if $fuzstr!=1 mul $fuzstr fi
+#     n 0,255 d
+    }
+#     rm. d
+#     split[REND] c  rm..  a[^0] c
+    blend_median[REND,FUZZ]  fi
+fi
+
+local[REND]
+  if $cracks
+    if $sckrad  deform 1.5 sharpen $sckrad,$sck dilate_oct 1.5 sharpen $sckrad,$sck fi
+    if $lgtone
+      repeat 3 {
+        fx_light_relief $lgtone,$lgttwo,$lgthree,0,0.2,50,50,20,0.084,0,0
+        b 2 erode_oct 3 sharpen $sckrad
+      }
+    fi
+  fi
+
+  if $wc
+    if $bilrep>0
+      repeat $bilrep {
+        deform {0,w/1000} bilateral $bilsize,$bilsize,$bilsize,$bilsize
+      }
+    fi
+  fi
+done
+
+if $post
+  if $huestr
+    [ORIG] nm. HUE
+    [ORIG] nm. SAT
+    b[HUE,SAT] 5
+    blend[HUE,REND] hue,$huestr
+    blend[SAT,REND] saturation,$huestr
+  fi
+fi
+
+if $sketch
+  if $linestr>0
+    [ORIG] nm. LINE
+    l[LINE] {
+      if {$__ORIGW/2}>1500 r 50%,50%,1,4,6 fi
+      deform {0,w/2000} rolling_guidance {31-$sklike},20,0
+      if {$__ORIGW/2}>1500 r 200%,200%,1,4,6 fi
+      gradient_norm negate
+#         edges 9%
+#     . negate.. deform. 4 split. c +compose_channels.. mul append[^0] c
+#       blend alpha,1
+      if $brkstr>0
+        . repeat 2 fx_breaks. 1,5,20,0,3  done
+        blend[-1,-2,LINE] multiply,$brkstr
+      fi
+      if $linthick
+        erode_circ. {$linthick/2}
+        spread. {$linthick/10}
+        dilate_circ. {$linthick/10}
+        b. {$linthick/5}
+        if {$linthick/5}>=3 sharpen. {$linthck*100} else sharpen. 100 fi
+      fi
+    adjust_colors. ,$cutmin,$cutmax,, n. 0,255 spread. 0.5
+    +store. line
+    }
+    split[REND] c a[1,2,3] c
+#     shared[REND] 100% . rm.. d
+    blend[LINE,REND] $skmerge,$linestr
+#     to_rgb.
+#     +compose_channels. +
+#     a[-1,-2] c
+  if $wl>0
+    $line negate. erode_circ. {$linthick/2}
+    if $wldef deform. $wldef fi
+    . blend[REND,LINE] or,$wl blend[-1,-2] add,1
+  fi
+  a[REND] [-1],c
+#   rm. d
+  fi
+fi
+
+n[REND] 0,255
+keep[REND]
+
+if $post
+  usrmod=$bri,$con,$gam,$hue,$sat
+  if [$usrmod]!=[0,0,0,0,0] adjust_colors[REND] $bri,$con,$gam,$hue,$sat fi
+fi
+
+if $dccires repeat $dccires { r 200%,200%,1,4,6 } fi
+
+if $noistr fx_noise $noistr,0,11,1,0,50,50 fi
+
+if $cnvs
+  +fc 255,255,255 noise. 50,2 to_gray. . .
+  if $cvmod
+    __wat=water.
+    __watb=water..
+    __watv=$cvmod,1,45
+  else
+    __wat=b.
+    __watb=b..
+    __watv=0
+  fi
+  parallel " blur_x. 30  $__wat $__watv  sharpen. 50  spread. 1.7 "," blur_y.. 30  $__watb $__watv sharpen.. 50 spread.. 1.7  "
+  *. .. keep[0,-1] n. 0,255 +gradient. xy,1 -a[-2,-1] c *. {$cnvs/100} warp[REND] .,3,1,1,1
+fi
+
++fc[REND] $cvr,$cvg,$cvb,$cva
+move[-1] 0
+blend[0,REND] alpha
+nm[0] REND
+keep[REND]
+
+#  +adjust_colors. 0,100,50
+# . repeat 2 glow. 1%  done sharpen. 100 to_gray.
+# b. 5 d
+
+#  blend burn,0.6
+
+if $post
+  if $emboss fx_emboss_relief 5,0,0.5,$emboss,1,0,1 fi
+fi
+
+if $com
+  expand_y 35,0
+  shift 0,35
+  text "${1--1}",10,30,12,1,255
+  text $distmerge" "$plasmerge" "$skmerge,10,50,20,1,255
+fi
+
+uglify_preview :
+
+__output=${1--2}
+preset,old_preset={[$5,${-1}]}
+
+if $preset==1
+  variables=0,1,1000,0,1,0,0,0,0,0,0,0,13,0,0,0,0,0,0,0,-1,-100,0,23,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,22,0,0,0,255,255,255,255,0,0,0,0,0,0,0,0
+elif $preset==2
+  variables=0,1,1000,0,2,1,0,2,0,1,20,10,7,0.4,1,12,2,127,42,0.365,-1,0,0,11,0.5,1,1,0,0.01,0.02,0.02,1,30,0,0,5,1,0,1,4,22,6,0,0,255,255,255,255,1,0,0.8,0,0,9,0,0
+elif $preset==3
+  variables=0,1,1000,0,3,0,0,0,0.3,1,3,3,13,0.5,1,12,1,0,20,0.5,-1,-100,0,37,0.755,1,500,1,0.027,0.02,0.02,1,25,0,0,2,1,0.9,1,4,22,6,0.3,0,255,255,255,255,1,1.5,1,0,0,31,0,0
+elif $preset==4
+  variables=0,1,1000,0,0,1,500,0,0.366,0,3,3,13,0.5,1,10,0,0,0,0.5,-1,80,0,7,0.2,1,0,1,0.134,0.02,0.02,1,29,0,0,0,0.707,0,1,1.6,19,6,0.61,11,255,255,255,255,1,1.1,0,0,0,0,0,-100
+#   uglify 0,1,1000,0,0,1,500,0,0.366,0,3,3,13,0.5,1,10,0,0,0,0.5,-1,80,0,7,0.2,1,0,1,0.134,0.02,0.02,1,29,0,0,0,0.707,0,1,4,19,6,0.61,11,255,255,255,255,1,1.1,0,0,0,0,0,-100,0
+elif $preset==5
+  variables=0,1,1000,0,0,1,308,0,2.3736,1,3,3,0,0.5,1,23,2,350,1,0.5,-1,100,0,10,1,1,0,1,0.2,0.02,0.02,1,29,0,0,2,0.9,1,1,1.6,22,6,1,19,134,110,71,255,1,1,0,0,0,13.4,0,-100
+elif $preset==6
+  variables=0,1,1000,0,0,0,0,0,0.3,0,3,3,13,0.5,1,12,0,0,20,0.5,437767,-100,19.75,37,1,1,500,0,0.021,0.02,0.02,1,20,0,0,4,1,1,1,4,13,0,0,16,125,125,125,255,1,0.965,1,0,-47.6,0,0,0
+fi
+
+if $preset
+  if $preset==$old_preset
+    if [$__output]!=[$variables]
+      __output=${1-4},0,${6--2}
+    fi
+else
+  __output=$variables
+  fi
+fi
+
+com,origres,procres,dccires,preset,bst,bstsharp,bstblur,locnorm,\
+filt,dist,distblur,distmerge,diststr,wc,bilsize,bilrep,fuzz,fuzzblur,\
+fuzstr,plsmseed,plsmsat,plsmblur,plasmerge,plastr,cracks,sckrad,sck,lgtone,\
+lgttwo,lgthree,sketch,sklike,cutmin,cutmax,linthick,linestr,brkstr,wl,wldef,skmerge,\
+noistr,cnvs,cvmod,cvr,cvg,cvb,cva,post,emboss,huestr,\
+bri,con,gam,hue,sat=$__output
+
+uglify $__output
+
+u "{"$com"}""{"$origres"}""{"$procres"}""{"$dccires"}""{"$preset"}""{"$bst"}""{"$bstsharp"}""{"$bstblur"}""{"$locnorm"}"\
+"{"$filt"}""{"$dist"}""{"$distblur"}""{"$distmerge"}""{"$diststr"}""{"$wc"}""{"$bilsize"}""{"$bilrep"}""{"$fuzz"}""{"$fuzzblur"}"\
+"{"$fuzstr"}""{"$plsmseed"}""{"$plsmsat"}""{"$plsmblur"}""{"$plasmerge"}""{"$plastr"}""{"$cracks"}""{"$sckrad"}""{"$sck"}""{"$lgtone"}"\
+"{"$lgttwo"}""{"$lgthree"}""{"$sketch"}""{"$sklike"}""{"$cutmin"}""{"$cutmax"}""{"$linthick"}""{"$linestr"}""{"$brkstr"}""{"$wl"}""{"$wldef"}""{"$skmerge"}"\
+"{"$noistr"}""{"$cnvs"}""{"$cvmod"}""{"$cvr,$cvg,$cvb,$cva"}""{"$post"}""{"$emboss"}""{"$huestr"}"\
+"{"$bri"}""{"$con"}""{"$gam"}""{"$hue"}""{"$sat"}""{"$preset"}"
+
+
 # Local Variables:
 # mode: sh
 # End:


### PR DESCRIPTION
Added the Uglify (temporary name) filter to Testing > Prawnsushi (if I did it right this time).
Not finished yet but usable.
Note: I used int sliders instead of booleans because, for some reason, checkboxes make the preview apply the filter twice.
Only way i found to prevent this is to either deactivate preview update for checkboxes, or use sliders.